### PR TITLE
Add the next buses as an attr to the sensor

### DIFF
--- a/custom_components/first_bus/sensor.py
+++ b/custom_components/first_bus/sensor.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import (timedelta)
 import logging
 
@@ -83,12 +84,13 @@ class FirstBusNextBus(SensorEntity):
       self._minsSinceLastUpdate = 5
     
     next_bus = get_next_bus(self._buses, self._data[CONFIG_BUSES], now())
-    self._attributes = next_bus
+    self._attributes = copy.copy(next_bus)
     if (self._attributes is None):
       self._attributes = {}
     
     self._attributes["stop"] = self._data[CONFIG_STOP]
-
+    self._attributes["buses"] = self._buses
+    
     if next_bus is not None:
       self._state = next_bus["Due"]
     else:


### PR DESCRIPTION
So it would be nice as we are fetching the data to make it available. This adds the buses data to the sensor as an attribute.

It enables the rendering of pages such as

![Buses](https://github.com/BottlecapDave/HomeAssistant-FirstBus/assets/1085290/77ab85ff-3fda-4760-b2ce-d314fba047ad)
