### PR TITLE
Live refresh service

### DIFF
--- a/custom_components/first_bus/services.yaml
+++ b/custom_components/first_bus/services.yaml
@@ -1,0 +1,4 @@
+live_refresh:
+  target:
+    entity:
+      domain: sensor

--- a/custom_components/first_bus/translations/en.json
+++ b/custom_components/first_bus/translations/en.json
@@ -40,5 +40,11 @@
     },
     "abort": {
     }
+  },
+  "services": {
+    "live_refresh": {
+      "name": "Live refresh",
+      "description": "Refresh timetable from First Bus website."
+    }
   }
 }


### PR DESCRIPTION
As much an academic exercise as anything but I find the live times , especially at rush hours, can fluctuate minute by minute so thought it would be nice to have a "live refresh" service and to add the last proper update time as an attribute to the entity. Dropped it in a custom card (which needs some tidying up) like so:

![image](https://github.com/BottlecapDave/HomeAssistant-FirstBus/assets/46966087/141a7876-a6dc-43fb-8185-fb379da56fa0)
